### PR TITLE
Read full pages when walking page table and improve scanning perf

### DIFF
--- a/libmquire/src/architecture/intel/architecture.rs
+++ b/libmquire/src/architecture/intel/architecture.rs
@@ -274,12 +274,18 @@ impl Architecture for IntelArchitecture {
         readable: &dyn Readable,
         root_page_table: PhysicalAddress,
     ) -> Result<Vec<Region>> {
-        let reader = Reader::new(readable, true);
         let mut region_list = Vec::new();
 
-        for pml4_index in 0..512u64 {
-            let table_entry_offset = pml4_index * 8;
-            let raw_table_entry = reader.read_u64(root_page_table + table_entry_offset)?;
+        // Read the entire PML4 table (4096 bytes = 512 entries)
+        let mut pml4_buffer = [0u8; 4096];
+        readable.read_exact(&mut pml4_buffer, root_page_table)?;
+
+        for (pml4_index, chunk) in pml4_buffer.chunks_exact(8).enumerate() {
+            let pml4_index = pml4_index as u64;
+            let Ok(bytes) = <[u8; 8]>::try_from(chunk) else {
+                continue;
+            };
+            let raw_table_entry = u64::from_le_bytes(bytes);
 
             let pml4_page_directory =
                 match PageTableEntry::new(PageTableLevel::Pml4, raw_table_entry) {
@@ -294,16 +300,24 @@ impl Architecture for IntelArchitecture {
                     _ => continue,
                 };
 
-            for pdpt_index in 0..512u64 {
-                let table_entry_offset = pdpt_index * 8;
+            // Read the entire PDPT table
+            let mut pdpt_buffer = [0u8; 4096];
+            if readable
+                .read_exact(
+                    &mut pdpt_buffer,
+                    PhysicalAddress::new(pml4_page_directory.physical_address),
+                )
+                .is_err()
+            {
+                continue;
+            }
 
-                let raw_table_entry = if let Ok(raw_table_entry) = reader.read_u64(
-                    PhysicalAddress::new(pml4_page_directory.physical_address + table_entry_offset),
-                ) {
-                    raw_table_entry
-                } else {
+            for (pdpt_index, chunk) in pdpt_buffer.chunks_exact(8).enumerate() {
+                let pdpt_index = pdpt_index as u64;
+                let Ok(bytes) = <[u8; 8]>::try_from(chunk) else {
                     continue;
                 };
+                let raw_table_entry = u64::from_le_bytes(bytes);
 
                 let pdpt_page_directory =
                     match PageTableEntry::new(PageTableLevel::Pdpt, raw_table_entry) {
@@ -339,17 +353,24 @@ impl Architecture for IntelArchitecture {
                         _ => continue,
                     };
 
-                for pd_index in 0..512u64 {
-                    let table_entry_offset = pd_index * 8;
+                // Read the entire PD table
+                let mut pd_buffer = [0u8; 4096];
+                if readable
+                    .read_exact(
+                        &mut pd_buffer,
+                        PhysicalAddress::new(pdpt_page_directory.physical_address),
+                    )
+                    .is_err()
+                {
+                    continue;
+                }
 
-                    let raw_table_entry = if let Ok(raw_table_entry) =
-                        reader.read_u64(PhysicalAddress::new(
-                            pdpt_page_directory.physical_address + table_entry_offset,
-                        )) {
-                        raw_table_entry
-                    } else {
+                for (pd_index, chunk) in pd_buffer.chunks_exact(8).enumerate() {
+                    let pd_index = pd_index as u64;
+                    let Ok(bytes) = <[u8; 8]>::try_from(chunk) else {
                         continue;
                     };
+                    let raw_table_entry = u64::from_le_bytes(bytes);
 
                     let pd_page_directory =
                         match PageTableEntry::new(PageTableLevel::Pd, raw_table_entry) {
@@ -388,17 +409,24 @@ impl Architecture for IntelArchitecture {
                             _ => continue,
                         };
 
-                    for pt_index in 0..512u64 {
-                        let table_entry_offset = pt_index * 8;
+                    // Read the entire PT table
+                    let mut pt_buffer = [0u8; 4096];
+                    if readable
+                        .read_exact(
+                            &mut pt_buffer,
+                            PhysicalAddress::new(pd_page_directory.physical_address),
+                        )
+                        .is_err()
+                    {
+                        continue;
+                    }
 
-                        let raw_table_entry = if let Ok(raw_table_entry) =
-                            reader.read_u64(PhysicalAddress::new(
-                                pd_page_directory.physical_address + table_entry_offset,
-                            )) {
-                            raw_table_entry
-                        } else {
+                    for (pt_index, chunk) in pt_buffer.chunks_exact(8).enumerate() {
+                        let pt_index = pt_index as u64;
+                        let Ok(bytes) = <[u8; 8]>::try_from(chunk) else {
                             continue;
                         };
+                        let raw_table_entry = u64::from_le_bytes(bytes);
 
                         if let Ok(PageTableEntry::Page(page)) =
                             PageTableEntry::new(PageTableLevel::Pt, raw_table_entry)

--- a/libmquire/src/operating_system/linux/kallsyms.rs
+++ b/libmquire/src/operating_system/linux/kallsyms.rs
@@ -239,7 +239,7 @@ impl Kallsyms {
             }
         };
 
-        let mut memory_range_list: Vec<Range<u64>> = architecture
+        let memory_range_list: Vec<Range<u64>> = architecture
             .enumerate_page_table_regions(memory_dump, root_page_table)?
             .into_iter()
             .map(|region| {
@@ -252,8 +252,6 @@ impl Kallsyms {
                 }
             })
             .collect();
-
-        memory_range_list.sort_by_key(|range| range.start);
 
         let scan_session_list = Self::scan_for_kallsyms_token_table(
             memory_dump,

--- a/libmquire/src/utils/memory_scanner.rs
+++ b/libmquire/src/utils/memory_scanner.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use std::ops::Range;
 
-/// Scans virtual memory for a byte pattern using a sliding window.
+/// Scans virtual memory for a byte pattern using Boyer-Moore-Horspool algorithm.
 pub struct MemoryScanner<'a> {
     vmem_reader: &'a VirtualMemoryReader<'a>,
     start: VirtualAddress,
@@ -29,6 +29,8 @@ pub struct MemoryScanner<'a> {
     current_read_buffer_offset: usize,
     pattern: Vec<u8>,
     current_range_start: VirtualAddress,
+    /// Boyer-Moore-Horspool bad character skip table
+    skip_table: [usize; 256],
 }
 
 impl<'a> MemoryScanner<'a> {
@@ -51,6 +53,12 @@ impl<'a> MemoryScanner<'a> {
             range_list.push(range);
         }
 
+        // Build Boyer-Moore-Horspool bad character skip table
+        let mut skip_table = [pattern_len; 256];
+        for (i, &byte) in pattern[..pattern_len - 1].iter().enumerate() {
+            skip_table[byte as usize] = pattern_len - 1 - i;
+        }
+
         Ok(Self {
             vmem_reader,
             start,
@@ -62,6 +70,7 @@ impl<'a> MemoryScanner<'a> {
             current_read_buffer_offset: 0,
             pattern: pattern.to_vec(),
             current_range_start: start,
+            skip_table,
         })
     }
 
@@ -84,20 +93,27 @@ impl<'a> Iterator for MemoryScanner<'a> {
     type Item = Result<VirtualAddress>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let pattern_len = self.pattern.len();
+
         loop {
-            if self.current_read_buffer_offset + self.pattern.len() <= self.bytes_read {
+            if self.current_read_buffer_offset + pattern_len <= self.bytes_read {
                 //
-                // Advance the sliding window by one byte and try to match the pattern.
+                // Boyer-Moore-Horspool: compare pattern and skip based on bad character
                 //
 
                 let window = &self.read_buffer[self.current_read_buffer_offset
-                    ..self.current_read_buffer_offset + self.pattern.len()];
+                    ..self.current_read_buffer_offset + pattern_len];
 
                 let current_offset = self.current_read_buffer_offset;
-                self.current_read_buffer_offset += 1;
 
                 if window == self.pattern.as_slice() {
+                    // Match found - advance by 1 to find overlapping matches
+                    self.current_read_buffer_offset += 1;
                     return Some(Ok(self.current_range_start + current_offset as u64));
+                } else {
+                    // No match - skip based on the last byte in the window
+                    let last_byte = window[pattern_len - 1];
+                    self.current_read_buffer_offset += self.skip_table[last_byte as usize];
                 }
             } else if let Some(range) = self.range_list.get(self.current_range_index) {
                 //
@@ -565,5 +581,106 @@ mod tests {
         let scanner = MemoryScanner::new(&reader, start, end, pattern).unwrap();
 
         assert_eq!(scanner.pattern(), pattern);
+    }
+
+    /// Brute-force reference implementation for differential testing.
+    fn brute_force_search(data: &[u8], pattern: &[u8]) -> Vec<usize> {
+        if pattern.is_empty() || pattern.len() > data.len() {
+            return Vec::new();
+        }
+        (0..=data.len() - pattern.len())
+            .filter(|&i| data[i..i + pattern.len()] == *pattern)
+            .collect()
+    }
+
+    /// Helper to run MemoryScanner and collect match offsets.
+    fn scanner_search(data: &[u8], pattern: &[u8]) -> Vec<usize> {
+        let memory = MockMemory::new(data.to_vec());
+        let arch = MockArchitecture;
+        let reader = VirtualMemoryReader::new(&memory, &arch);
+
+        let start = VirtualAddress::new(PhysicalAddress::from(0), RawVirtualAddress::new(0));
+        let end = VirtualAddress::new(
+            PhysicalAddress::from(0),
+            RawVirtualAddress::new(data.len() as u64),
+        );
+
+        let scanner = MemoryScanner::new(&reader, start, end, pattern).unwrap();
+        scanner
+            .filter_map(|r| r.ok())
+            .map(|addr| addr.value().value() as usize)
+            .collect()
+    }
+
+    #[test]
+    fn test_bmh_matches_brute_force() {
+        // Test case 1: Pattern with distinct bytes
+        let data = vec![
+            0x00, 0x11, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xDE, 0xAD, 0xBE, 0xEF,
+        ];
+        let pattern = &[0xDE, 0xAD, 0xBE, 0xEF];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 2: Overlapping matches (repeated bytes)
+        let data = vec![0xAA, 0xAA, 0xAA, 0xAA, 0xAA];
+        let pattern = &[0xAA, 0xAA];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 3: Pattern where last byte appears earlier
+        let data = vec![0x00, 0x01, 0x02, 0x01, 0x00, 0x01, 0x02, 0x03];
+        let pattern = &[0x01, 0x02, 0x03];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 4: Single byte pattern
+        let data = vec![0xFF, 0x00, 0xFF, 0x00, 0xFF];
+        let pattern = &[0xFF];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 5: Pattern at very end
+        let data = vec![0x00, 0x00, 0x00, 0xAB, 0xCD];
+        let pattern = &[0xAB, 0xCD];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 6: No matches
+        let data = vec![0x00, 0x11, 0x22, 0x33, 0x44];
+        let pattern = &[0xFF, 0xFF];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 7: Pattern same length as data
+        let data = vec![0xDE, 0xAD];
+        let pattern = &[0xDE, 0xAD];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
+
+        // Test case 8: Larger data with multiple scattered matches
+        let mut data = vec![0x00; 200];
+        data[10..14].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+        data[50..54].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+        data[196..200].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+        let pattern = &[0xCA, 0xFE, 0xBA, 0xBE];
+        assert_eq!(
+            scanner_search(&data, pattern),
+            brute_force_search(&data, pattern)
+        );
     }
 }


### PR DESCRIPTION
Uses a local buffer to read the full page instead of single u64 to reduce the number of reads.
Further, when scanning memory uses a more efficient algorithm that allows skipping more input bytes.