### PR TITLE
build: Prepare Cargo.toml for crates.io publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,17 @@
 name = "mquire"
 version = "0.1.0"
 edition = "2021"
+authors = ["Trail of Bits"]
+license = "Apache-2.0"
+description = "Memory forensics and analysis tool for querying Linux kernel memory dumps using SQL"
+repository = "https://github.com/trailofbits/mquire"
+documentation = "https://docs.rs/mquire"
+readme = "README.md"
+keywords = ["linux", "kernel", "memory", "forensics", "sql"]
+categories = ["command-line-utilities", "development-tools::debugging"]
 
 [dependencies]
+# Core library dependencies
 btfparse = "1.3.7"
 log = "0.4.29"
 memmap2 = "0.9"
@@ -19,9 +28,19 @@ rayon = "1.11.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.147"
 chrono = { version = "0.4.42", features = ["clock"], default-features = false }
-clap = { version = "4.5", features = ["derive"] }
 thiserror = "2.0"
-rustyline = { version = "17.0.2", default-features = false }
+
+# CLI-only dependencies
+clap = { version = "4.5", features = ["derive"], optional = true }
+rustyline = { version = "17.0.2", default-features = false, optional = true }
+
+[features]
+default = ["cli"]
+cli = ["clap", "rustyline"]
+
+[[bin]]
+name = "mquire"
+required-features = ["cli"]
 
 [build-dependencies]
 cc = "1.2.50"


### PR DESCRIPTION
Make CLI dependencies (clap, rustyline) optional to reduce compile time for library users

Add required publishing metadata