### PR TITLE
build: stage packages outside temp dirs

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,3 +48,7 @@ package:
     cargo build --release --target x86_64-unknown-linux-musl
     cmake -S package -B package-build -DMQUIRE_REPOSITORY_PATH="$(pwd)"
     cmake --build package-build --target package
+    mkdir -p dist
+    find package-build -maxdepth 1 -type f -name 'mquire-*' -exec cp -f {} dist/ \;
+    rm -rf package-build
+    cargo clean --target x86_64-unknown-linux-musl


### PR DESCRIPTION
## Summary
- copy packaged release artifacts into `dist/` before cleanup
- remove temporary `package-build/` output after packaging
- clear musl target intermediates after the package recipe completes

## Notes
- release artifacts that may be used in production are preserved
- cleanup only targets debug and intermediate build artifacts by default

## Validation
- `just --list`
- `git diff --check`